### PR TITLE
feat:weekly email send

### DIFF
--- a/configs/config_dev.yaml
+++ b/configs/config_dev.yaml
@@ -11,14 +11,19 @@ user:
     email: "admin@example.com"
     password: "securepassword"
 
-captcha:
+smtp:
   smtpUser: ""
-  smtpNickname: "BBingYan"
+  smtpNickname: ""
   smtpPassword: ""
   smtpHost: "smtp.qq.com"
   smtpPort: "587"
-  expire: "15m"
-  interval: "1m"
+  captcha:
+    expire: "15m"
+    interval: "1m"
+  weeklyEmail:
+    routineNum: 10
+    timeOut: "10s"
+    rateLimit: "1m"
 
 jwt:
   secret: "your_jwt_secret"
@@ -38,3 +43,5 @@ redis:
 
 bcrypt:
   cost: 10
+
+

--- a/configs/config_prod.yaml
+++ b/configs/config_prod.yaml
@@ -11,14 +11,19 @@ user:
     email: "admin@example.com"
     password: "securepassword"
 
-captcha:
+smtp:
   smtpUser: ""
-  smtpNickname: "BBingYan"
+  smtpNickname: ""
   smtpPassword: ""
   smtpHost: "smtp.qq.com"
   smtpPort: "587"
-  expire: "15m"
-  interval: "1m"
+  captcha:
+    expire: "15m"
+    interval: "1m"
+  weeklyEmail:
+    routineNum: 10
+    timeOut: "10s"
+    rateLimit: "1m"
 
 jwt:
   secret: "your_jwt_secret"

--- a/configs/config_test.yaml
+++ b/configs/config_test.yaml
@@ -11,14 +11,19 @@ user:
     email: "admin@example.com"
     password: "securepassword"
 
-captcha:
+smtp:
   smtpUser: ""
-  smtpNickname: "BBingYan"
+  smtpNickname: ""
   smtpPassword: ""
   smtpHost: "smtp.qq.com"
   smtpPort: "587"
-  expire: "15m"
-  interval: "1m"
+  captcha:
+    expire: "15m"
+    interval: "1m"
+  weeklyEmail:
+    routineNum: 10
+    timeOut: "10s"
+    rateLimit: "1m"
 
 jwt:
   secret: "your_jwt_secret"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,12 +6,12 @@ type Config struct {
 	Server   *ServerConfig        `yaml:"server"`
 	Postgres *PostgresConfig      `yaml:"postgres"`
 	User     *UserConfig          `yaml:"user"`
-	Captcha  *CaptchaConfig       `yaml:"captcha"`
 	JWT      *JWTConfig           `yaml:"jwt"`
 	Bcrypt   *BcryptConfig        `yaml:"bcrypt"`
 	Log      *LogConfig           `yaml:"log"`
 	Redis    *RedisConfig         `yaml:"redis"`
 	ES       *ElasticsearchConfig `yaml:"elasticsearch"`
+	Smtp     *SmtpConfig          `yaml:"smtp"`
 }
 
 type ServerConfig struct {
@@ -20,27 +20,8 @@ type ServerConfig struct {
 	Env  string `yaml:"env"`
 }
 
-type UserConfig struct {
-	InitAdmin *InitAdminConfig `yaml:"initAdmin"`
-}
-
 type PostgresConfig struct {
 	Dsn string `yaml:"dsn"`
-}
-
-type InitAdminConfig struct {
-	Email    string `yaml:"email"`
-	Password string `yaml:"password"`
-}
-
-type CaptchaConfig struct {
-	SmtpUser     string `yaml:"smtpUser"`
-	SmtpNickname string `yaml:"smtpNickname"`
-	SmtpPassword string `yaml:"smtpPassword"`
-	SmtpHost     string `yaml:"smtpHost"`
-	SmtpPort     string `yaml:"smtpPort"`
-	Expire       string `yaml:"expire"`
-	Interval     string `yaml:"interval"`
 }
 
 type JWTConfig struct {

--- a/internal/config/smtp.go
+++ b/internal/config/smtp.go
@@ -1,0 +1,22 @@
+package config
+
+type SmtpConfig struct {
+	SmtpUser     string             `yaml:"smtpUser"`
+	SmtpNickname string             `yaml:"smtpNickname"`
+	SmtpPassword string             `yaml:"smtpPassword"`
+	SmtpHost     string             `yaml:"smtpHost"`
+	SmtpPort     string             `yaml:"smtpPort"`
+	Captcha      *CaptchaConfig     `yaml:"captchaConfig"`
+	WeeklyEmail  *WeeklyEmailConfig `yaml:"weeklyEmail"`
+}
+
+type CaptchaConfig struct {
+	Expire   string `yaml:"expire"`
+	Interval string `yaml:"interval"`
+}
+
+type WeeklyEmailConfig struct {
+	RoutineNum int    `yaml:"routineNum"`
+	TimeOut    string `yaml:"timeOut"`
+	RateLimit  string `yaml:"rateLimit"`
+}

--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -1,0 +1,10 @@
+package config
+
+type UserConfig struct {
+	InitAdmin *InitAdminConfig `yaml:"initAdmin"`
+}
+
+type InitAdminConfig struct {
+	Email    string `yaml:"email"`
+	Password string `yaml:"password"`
+}

--- a/internal/controller/weeklyEmail.go
+++ b/internal/controller/weeklyEmail.go
@@ -52,3 +52,24 @@ func GetWeeklyEmailSendingHistory(c echo.Context) error {
 		},
 	})
 }
+
+// SubscribeWeeklyEmail 订阅周报
+func SubscribeWeeklyEmail(c echo.Context) error {
+	uid, err := context.GetUIDFromToken(c)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, params.Response{
+			Success: false,
+			Message: err.Error(),
+		})
+	}
+	if err = service.SubscribeWeeklyEmail(uid); err != nil {
+		return c.JSON(http.StatusBadRequest, params.Response{
+			Success: false,
+			Message: err.Error(),
+		})
+	}
+	return c.JSON(http.StatusOK, params.Response{
+		Success: true,
+		Message: "订阅成功",
+	})
+}

--- a/internal/controller/weeklyEmail.go
+++ b/internal/controller/weeklyEmail.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"github.com/FIY-pc/BBingyan/internal/controller/context"
+	"github.com/FIY-pc/BBingyan/internal/controller/params"
+	"github.com/FIY-pc/BBingyan/internal/service"
+	"github.com/labstack/echo/v4"
+	"net/http"
+)
+
+func SendWeeklyEmail(c echo.Context) error {
+	AdminID, err := context.GetUIDFromToken(c)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, params.Response{
+			Success: false,
+			Message: err.Error(),
+		})
+	}
+	service.SendWeeklyEmail(AdminID)
+	return c.JSON(http.StatusOK, params.Response{
+		Success: true,
+		Message: "后台发送进程已启动",
+	})
+}
+
+// GetWeeklyEmailSendingHistory 获取周报邮件发送历史记录
+func GetWeeklyEmailSendingHistory(c echo.Context) error {
+	// 因为过于简单，所以不单独把这个req放到集中的地方了
+	req := struct {
+		Page     int `json:"page" validate:"required"`
+		PageSize int `json:"pageSize" validate:"required"`
+	}{}
+
+	if err := context.BindAndValid(c, &req); err != nil {
+		return c.JSON(http.StatusBadRequest, params.Response{
+			Success: false,
+			Message: err.Error(),
+		})
+	}
+	history, total, err := service.GetWeeklyEmailSendingHistory(req.Page, req.PageSize)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, params.Response{
+			Success: false,
+			Message: err.Error(),
+		})
+	}
+	return c.JSON(http.StatusOK, params.Response{
+		Success: true,
+		Data: map[string]interface{}{
+			"total":   total,
+			"history": history,
+		},
+	})
+}

--- a/internal/infrastructure/postgres.go
+++ b/internal/infrastructure/postgres.go
@@ -21,6 +21,10 @@ func NewPostgres() {
 	if err = PostgresDb.AutoMigrate(&model.User{}); err != nil {
 		log.Fatal(err)
 	}
+	// migrate user related
+	if err = PostgresDb.AutoMigrate(&model.WeeklyEmailSendingHistory{}); err != nil {
+		log.Fatal(err)
+	}
 	// migrate post related
 	if err = PostgresDb.AutoMigrate(&model.Post{}); err != nil {
 		log.Fatal(err)

--- a/internal/middleware/rateLimit.go
+++ b/internal/middleware/rateLimit.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"github.com/FIY-pc/BBingyan/internal/controller/params"
+	"github.com/FIY-pc/BBingyan/internal/infrastructure"
+	"github.com/labstack/echo/v4"
+	"net/http"
+	"time"
+)
+
+// RateLimitMiddleware 时间间隔中间件，主要用于限制某些接口的访问频率，比如发送周报接口，防止误操作
+func RateLimitMiddleware(rawTime string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			TTL, err := time.ParseDuration(rawTime)
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, params.Response{
+					Success: false,
+					Message: "时间解析错误",
+				})
+			}
+			path := c.Path()
+			cmd := infrastructure.Rdb.Exists(c.Request().Context(), path)
+			if cmd.Val() == 1 {
+				return c.JSON(http.StatusTooManyRequests, params.Response{
+					Success: false,
+					Message: "操作过于频繁，请稍后再试",
+				})
+			}
+			infrastructure.Rdb.Set(c.Request().Context(), path, 1, TTL)
+			return next(c)
+		}
+	}
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -5,13 +5,14 @@ import (
 )
 
 type User struct {
-	UID      uint      `json:"uid" gorm:"primaryKey;autoIncrement"`
-	Email    string    `json:"email" gorm:"uniqueIndex;type:varchar(255);not null"`
-	Password string    `json:"-" gorm:"type:varchar(255);not null"` // 密码不输出到JSON
-	IsAdmin  bool      `json:"is_admin" gorm:"default:false"`
-	Nickname string    `json:"nickname" gorm:"unique"`
-	Intro    string    `json:"intro" gorm:"type:varchar(500);default:'无'"`
-	Avatar   string    `json:"avatar" gorm:"type:varchar(255);default:'/static/avatar/default.png'"`
-	CreateAt time.Time `json:"create_at" gorm:"autoCreateTime"`
-	UpdateAt time.Time `json:"update_at" gorm:"autoUpdateTime"`
+	UID                  uint      `json:"uid" gorm:"primaryKey;autoIncrement"`
+	Email                string    `json:"email" gorm:"uniqueIndex;type:varchar(255);not null"`
+	Password             string    `json:"-" gorm:"type:varchar(255);not null"` // 密码不输出到JSON
+	IsAdmin              bool      `json:"is_admin" gorm:"default:false"`
+	Nickname             string    `json:"nickname" gorm:"unique"`
+	Intro                string    `json:"intro" gorm:"type:varchar(500);default:'无'"`
+	Avatar               string    `json:"avatar" gorm:"type:varchar(255);default:'/static/avatar/default.png'"`
+	SubscribeWeeklyEmail bool      `json:"subscribe_weekly_email" gorm:"default:false"` // 是否订阅周报
+	CreateAt             time.Time `json:"create_at" gorm:"autoCreateTime"`
+	UpdateAt             time.Time `json:"update_at" gorm:"autoUpdateTime"`
 }

--- a/internal/model/weekly-email-history.go
+++ b/internal/model/weekly-email-history.go
@@ -1,0 +1,15 @@
+package model
+
+import "time"
+
+type WeeklyEmailSendingHistory struct {
+	ID           uint      `json:"id" gorm:"primaryKey;autoIncrement"`
+	AdminID      uint      `json:"admin_id"`                        // 进行发送周报操作的管理员ID
+	Emails       []string  `json:"emails" gorm:"type:json"`         // 接收周报的用户的邮箱
+	TotalCount   int       `json:"total_count"`                     // 总共发送的邮件数量
+	SuccessCount int       `json:"success_count"`                   // 发送成功的邮件数量
+	FailCount    int       `json:"fail_count"`                      // 发送失败的邮件数量
+	TimeOut      string    `json:"time_out"`                        // 发送超时时间配置
+	RoutineNum   int       `json:"routine_num"`                     // 发送邮件的协程数量
+	CreateAt     time.Time `json:"create_at" gorm:"autoCreateTime"` // 记录创建时间
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -110,6 +110,7 @@ func searchRouter(e *echo.Echo) {
 func weeklyEmailRouter(e *echo.Echo) {
 	basic := e.Group("/api/weekly-email")
 	basic.Use(middleware.BasicAuth)
+	basic.POST("/subscribe", controller.SubscribeWeeklyEmail)
 
 	admin := basic.Group("")
 	admin.Use(middleware.AdminAuth)

--- a/internal/service/weekly-email.go
+++ b/internal/service/weekly-email.go
@@ -11,6 +11,16 @@ import (
 	"time"
 )
 
+// SubscribeWeeklyEmail 订阅周报
+func SubscribeWeeklyEmail(UID uint) error {
+	user := model.User{}
+	if err := infrastructure.PostgresDb.Where("uid = ?", UID).First(&user).Error; err != nil {
+		return err
+	}
+	user.SubscribeWeeklyEmail = true
+	return infrastructure.PostgresDb.Save(&user).Error
+}
+
 // SendWeeklyEmail 后台多协程发送周报邮件
 func SendWeeklyEmail(AdminID uint) {
 	go func() {

--- a/internal/service/weekly-email.go
+++ b/internal/service/weekly-email.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"github.com/FIY-pc/BBingyan/internal/config"
+	"github.com/FIY-pc/BBingyan/internal/infrastructure"
+	"github.com/FIY-pc/BBingyan/internal/infrastructure/logger"
+	"github.com/FIY-pc/BBingyan/internal/model"
+	"github.com/FIY-pc/BBingyan/internal/utils"
+	"golang.org/x/net/context"
+	"sync"
+	"time"
+)
+
+// SendWeeklyEmail 后台多协程发送周报邮件
+func SendWeeklyEmail(AdminID uint) {
+	go func() {
+		var wg sync.WaitGroup
+		var routineNum = config.Configs.Smtp.WeeklyEmail.RoutineNum
+		var userEmails []string
+		var TotalSuccessCount int
+		var TotalFailCount int
+
+		// 获取超时时间
+		TimeOut, err := time.ParseDuration(config.Configs.Smtp.WeeklyEmail.TimeOut)
+		if err != nil {
+			logger.Log.Error(nil, err.Error())
+			return
+		}
+
+		// 查询所有订阅了周报的用户的 email
+		if err = infrastructure.PostgresDb.Model(&model.User{}).Where("subscribe_weekly_email = true").Pluck("email", &userEmails).Error; err != nil {
+			logger.Log.Error(nil, err.Error())
+			return
+		}
+
+		emailsChan := make(chan string, len(userEmails))
+		// 把所有的 email 放入 emailsChan里
+		for _, email := range userEmails {
+			emailsChan <- email
+		}
+		defer close(emailsChan)
+		// 这两个切片用来记录每个 goroutine 成功和失败的次数，最后累加生成结果，避免了锁争用造成的性能损失
+		var successCountList = make([]int, routineNum)
+		var failCountList = make([]int, routineNum)
+		// 创建发送协程
+		for i := 0; i < routineNum; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				for {
+					// 超时处理
+					var email string
+					var ok bool
+					ctx, cancel := context.WithTimeout(context.Background(), TimeOut)
+					select {
+					// 从 channel 里取出 email 发送
+					case email, ok = <-emailsChan:
+						if !ok {
+							cancel()
+							return // 如果 channel 关闭，说明所有 email 已经发送完毕，goroutine 退出
+						}
+						// 发送邮件
+						err := sendEmail(email)
+						if err == nil {
+							successCountList[i]++
+						} else {
+							failCountList[i]++
+						}
+					case <-ctx.Done():
+						logger.Log.Error(nil, "邮件发送超时", "email", email, "routine", i, "timeout", TimeOut)
+						continue
+					}
+					cancel()
+				}
+			}(i)
+		}
+		wg.Wait() // 等待所有 goroutine 完成
+		// 统计总的成功和失败次数
+		for i := 0; i < routineNum; i++ {
+			TotalSuccessCount += successCountList[i]
+			TotalFailCount += failCountList[i]
+		}
+		// 记录发送历史
+		history := model.WeeklyEmailSendingHistory{
+			AdminID:      AdminID,
+			Emails:       userEmails,
+			TotalCount:   TotalSuccessCount + TotalFailCount,
+			SuccessCount: TotalSuccessCount,
+			FailCount:    TotalFailCount,
+			TimeOut:      config.Configs.Smtp.WeeklyEmail.TimeOut,
+			RoutineNum:   routineNum,
+		}
+		infrastructure.PostgresDb.Create(&history)
+	}()
+}
+
+// GetWeeklyEmailSendingHistory 获取周报邮件发送历史
+func GetWeeklyEmailSendingHistory(pageNum int, pageSize int) ([]model.WeeklyEmailSendingHistory, int64, error) {
+	var histories []model.WeeklyEmailSendingHistory
+	var total int64
+	err := infrastructure.PostgresDb.
+		Model(&model.WeeklyEmailSendingHistory{}).
+		Count(&total).Order("created_at desc").
+		Offset((pageNum - 1) * pageSize).
+		Limit(pageSize).
+		Find(&histories).Error
+	return histories, total, err
+}
+
+// sendEmail 周报邮件发送函数
+func sendEmail(email string) error {
+	var subject = "Weekly Email"
+	body, err := utils.GenerateEmailBody("weekly-email.html", nil)
+	if err != nil {
+		return err
+	}
+	msg := utils.GenerateHTMLMsg(email, config.Configs.Smtp.SmtpUser, config.Configs.Smtp.SmtpNickname, subject, body)
+	return utils.SendEmail(email, subject, string(msg))
+}

--- a/internal/utils/email.go
+++ b/internal/utils/email.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"bytes"
+	"github.com/FIY-pc/BBingyan/internal/config"
+	"github.com/FIY-pc/BBingyan/internal/infrastructure/logger"
+	"html/template"
+	"net/smtp"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func GenerateHTMLMsg(email, user, nickname, subject, body string) []byte {
+	msg := []byte("To: " + email + "\r\n" +
+		"From: " + user + "\r\n" + "<" + nickname + ">\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"Content-Type: text/html; charset=\"UTF-8\"\r\n\r\n" +
+		body)
+	return msg
+}
+
+func GetTemplatePath(filename string) (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	// 使用 filepath 包来处理路径
+	path := strings.Split(dir, "BBingyan")[0]
+	templatePath := filepath.Join(path, "BBingyan"+"/web/templates/"+filename)
+	return templatePath, nil
+}
+
+// GenerateEmailBody 从模板文件生成邮件内容
+func GenerateEmailBody(filename string, data interface{}) (string, error) {
+	// 打开模板文件
+	filePath, err := GetTemplatePath(filename)
+	if err != nil {
+		logger.Log.Error(nil, err.Error())
+		return "", err
+	}
+	tmpl, err := template.ParseFiles(filePath)
+	if err != nil {
+		logger.Log.Error(nil, err.Error())
+		return "", err
+	}
+
+	// 创建一个字符串缓冲区来存储生成的内容
+	var body bytes.Buffer
+	err = tmpl.Execute(&body, data)
+	if err != nil {
+		return "", err
+	}
+	return body.String(), nil
+}
+
+// SendEmail 发送邮件
+func SendEmail(email, subject, body string) error {
+	var addr = config.Configs.Smtp.SmtpHost + ":" + config.Configs.Smtp.SmtpPort
+	var auth = smtp.PlainAuth("", config.Configs.Smtp.SmtpUser, config.Configs.Smtp.SmtpPassword, config.Configs.Smtp.SmtpHost)
+	var from = config.Configs.Smtp.SmtpUser
+	var to = []string{email}
+	var msg = GenerateHTMLMsg(email, config.Configs.Smtp.SmtpUser, config.Configs.Smtp.SmtpNickname, subject, body)
+	return smtp.SendMail(addr, auth, from, to, msg)
+}

--- a/web/templates/weekly-email.html
+++ b/web/templates/weekly-email.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>论坛每周内容精选</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            width: 80%;
+            margin: 20px auto;
+            background: white;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .header {
+            background: #007BFF;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .content {
+            padding: 20px;
+        }
+        .post {
+            margin-bottom: 20px;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        .post h2 {
+            margin: 0;
+            color: #007BFF;
+        }
+        .footer {
+            text-align: center;
+            padding: 10px;
+            background: #f4f4f4;
+            border-top: 1px solid #ddd;
+        }
+        a {
+            color: #007BFF;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <h1>论坛每周内容精选</h1>
+    </div>
+    <div class="content">
+        <div class="post">
+            <h2>本周热门话题</h2>
+            <p>讨论了关于最新科技趋势的精彩帖子，快来看看吧！</p>
+            <a href="#">阅读更多</a>
+        </div>
+        <div class="post">
+            <h2>用户分享</h2>
+            <p>我们的用户分享了他们的经验和见解，值得一读！</p>
+            <a href="#">阅读更多</a>
+        </div>
+        <div class="post">
+            <h2>活动预告</h2>
+            <p>不要错过即将举行的在线研讨会，报名链接在这里！</p>
+            <a href="#">阅读更多</a>
+        </div>
+    </div>
+    <div class="footer">
+        <p>感谢您的关注！如需取消订阅，请<a href="#">点击这里</a>.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### 变更类型

- [x] 新功能
- [x] 代码重构

### 相关问题
issue #43

- 完成了 邮件订阅

### 变更内容
- 重构了config，使其关系更清晰
- 重构了邮件发送相关函数，使其更通用
- 完成了邮件订阅功能，实现多协程发送、信息统计和历史记录
- 新建了一个rateLimit中间件，目前主要用于限制周报发送API，防止短时间误操作多次发送
- web/template中更新一个周报邮件模版


### 其他信息
可重点关注的内容如下：
- internal/service/weekly-email.go
- internal/utils/email.go
- internal/middleware/rateLimit.go

次要内容：
- internal/model/weekly-email-history
- internal/auth.go
- internal/router.go
